### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shadowdiff.yml
+++ b/.github/workflows/shadowdiff.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   shadowdiff:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/theroutercompany/api_router/security/code-scanning/6](https://github.com/theroutercompany/api_router/security/code-scanning/6)

In general, the fix is to explicitly set a `permissions` block to restrict the `GITHUB_TOKEN` to the minimum required scope. Since this workflow only checks out code and runs tests/scripts, `contents: read` is sufficient in almost all such setups. We can apply this at the job level for `shadowdiff`, which is exactly where CodeQL reported the issue.

The best minimal fix without changing existing behavior is to add a `permissions:` section under the `shadowdiff` job (same indentation level as `runs-on`) and set `contents: read`. No other permissions seem necessary based on the visible steps. Concretely, in `.github/workflows/shadowdiff.yml`, just below `shadowdiff:` (and before or after `runs-on:`), add:

```yaml
    permissions:
      contents: read
```

No imports or other definitions are needed since this is a YAML workflow file; we only adjust the job configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
