### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/theroutercompany/api_router/security/code-scanning/7](https://github.com/theroutercompany/api_router/security/code-scanning/7)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions in this workflow. The safest and simplest approach is to add a `permissions` block at the top (workflow level) so it applies to all jobs that don’t override it. Since this CI job only reads the repository (checkout, go test, build docs, generate artifacts) and does not push commits, modify issues, or change pull requests, we can set `contents: read` as recommended by CodeQL.

Concretely, in `.github/workflows/ci.yml`, insert a `permissions:` section near the top of the file, right after the `name: CI` line and before the `on:` block. This block should set `contents: read`. No additional imports or methods are needed; this is a pure YAML configuration change and does not alter any steps’ functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
